### PR TITLE
Grouping of API endpoints in SwaggerUI and Bulk delete function

### DIFF
--- a/cfms-web-api/cfms-web-api/Controllers/v2/CustomerController.cs
+++ b/cfms-web-api/cfms-web-api/Controllers/v2/CustomerController.cs
@@ -151,6 +151,20 @@ namespace cfms_web_api.Controller.v2
             }
             return deletedCustomers;
         }
+
+        /// <summary>
+        /// Deletes all customer records.
+        /// </summary>
+        /// <returns>The HTTP status code.</returns>
+        /// <response code="200">If all customer deletions were successful.</response>
+        /// <response code="404">If nothing was found.</response>
+        [HttpDelete("All")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(404)]
+        public void DeleteAllCustomers()
+        {
+            _CustomerService.DeleteAllCustomers();
+        }
         #endregion
     }
 }

--- a/cfms-web-api/cfms-web-api/Controllers/v2/CustomerController.cs
+++ b/cfms-web-api/cfms-web-api/Controllers/v2/CustomerController.cs
@@ -16,10 +16,14 @@ namespace cfms_web_api.Controller.v2
             _CustomerService = CustomerService;
         }
 
+        #region GET Methods
         /// <summary>
         /// Retrieves all customers.
         /// </summary>
+        /// <returns>The HTTP status code and a list of all customers.</returns>
+        /// <response code="200">Returns a list of all customers.</response>
         [HttpGet]
+        [ProducesResponseType(200, Type = typeof(List<Customer>))]
         public ActionResult<List<Customer>> GetAllCustomers()
         {
             return _CustomerService.GetAllCustomers();
@@ -29,7 +33,12 @@ namespace cfms_web_api.Controller.v2
         /// Retrieves a customer by ID.
         /// </summary>
         /// <param name="id">The ID of the customer to retrieve.</param>
+        /// <returns>The HTTP status code and the customer with the specified ID.</returns>
+        /// <response code="200">Returns the customer with the specified ID.</response>
+        /// <response code="404">If the customer is not found.</response>
         [HttpGet("{id}")]
+        [ProducesResponseType(200, Type = typeof(Customer))]
+        [ProducesResponseType(404)]
         public ActionResult<Customer> GetCustomerById(string id)
         {
             var Customer = _CustomerService.GetCustomerById(id);
@@ -41,10 +50,44 @@ namespace cfms_web_api.Controller.v2
         }
 
         /// <summary>
+        /// Searches for customers based on a search term.
+        /// </summary>
+        /// <param name="searchTerm">The search term to match against customer names or emails.</param>
+        /// <returns>The HTTP status code and a list of customers matching the search term.</returns>
+        /// <response code="200">Returns a list of customers matching the search term.</response>
+        [HttpGet("Search")]
+        [ProducesResponseType(200, Type = typeof(List<Customer>))]
+        public ActionResult<List<Customer>> SearchCustomers(string searchTerm)
+        {
+            return _CustomerService.SearchCustomers(searchTerm);
+        }
+
+        /// <summary>
+        /// Retrieves a specific page of customers based on pagination parameters.
+        /// </summary>
+        /// <param name="pageNumber">The page number.</param>
+        /// <param name="pageSize">The page size.</param>
+        /// <returns>The HTTP status code and a page of customers.</returns>
+        /// <response code="200">Returns a page of customers.</response>
+        [HttpGet("Page")]
+        [ProducesResponseType(200, Type = typeof(List<Customer>))]
+        public ActionResult<List<Customer>> GetCustomersPage(int pageNumber, int pageSize)
+        {
+            return _CustomerService.GetCustomersPage(pageNumber, pageSize);
+        }
+
+        #endregion
+
+        #region POST Methods
+
+        /// <summary>
         /// Adds a new customer.
         /// </summary>
         /// <param name="Customer">The customer to add.</param>
+        /// <returns>The HTTP status code and the added customer.</returns>
+        /// <response code="201">Returns the added customer.</response>
         [HttpPost]
+        [ProducesResponseType(201, Type = typeof(List<Customer>))]
         public ActionResult<List<Customer>> AddCustomer(Customer Customer)
         {
             return _CustomerService.AddCustomer(Customer);
@@ -54,18 +97,29 @@ namespace cfms_web_api.Controller.v2
         /// Adds multiple customers in bulk.
         /// </summary>
         /// <param name="customers">The list of customers to add.</param>
+        /// <returns>The HTTP status code and the added customers.</returns>
+        /// <response code="201">Returns the added customers.</response>
         [HttpPost("Bulk")]
+        [ProducesResponseType(201, Type = typeof(List<Customer>))]
         public ActionResult<List<Customer>> AddCustomers(List<Customer> customers)
         {
             return _CustomerService.AddCustomers(customers);
         }
 
+        #endregion
+
+        #region PUT Methods
         /// <summary>
         /// Updates a customer.
         /// </summary>
         /// <param name="id">The ID of the customer to update.</param>
         /// <param name="Customer">The updated customer data.</param>
+        /// <returns>The HTTP status code and the updated customer.</returns>
+        /// <response code="200">Returns the updated customer.</response>
+        /// <response code="404">If the customer is not found.</response>
         [HttpPut("{id}")]
+        [ProducesResponseType(200, Type = typeof(List<Customer>))]
+        [ProducesResponseType(404)]
         public ActionResult<List<Customer>> UpdateCustomer(string id, Customer Customer)
         {
             var updatedCustomers = _CustomerService.UpdateCustomer(id, Customer);
@@ -75,12 +129,19 @@ namespace cfms_web_api.Controller.v2
             }
             return updatedCustomers;
         }
+        #endregion
 
+        #region DELETE Methods
         /// <summary>
         /// Deletes a customer.
         /// </summary>
         /// <param name="id">The ID of the customer to delete.</param>
+        /// <returns>The HTTP status code.</returns>
+        /// <response code="200">If the deletion was successful.</response>
+        /// <response code="404">If the customer is not found.</response>
         [HttpDelete("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(404)]
         public ActionResult<List<Customer>> DeleteCustomer(string id)
         {
             var deletedCustomers = _CustomerService.DeleteCustomer(id);
@@ -90,28 +151,6 @@ namespace cfms_web_api.Controller.v2
             }
             return deletedCustomers;
         }
-
-        /// <summary>
-        /// Searches for customers based on a search term.
-        /// </summary>
-        /// <param name="searchTerm">The search term to match against customer names or emails.</param>
-        [HttpGet("Search")]
-        public ActionResult<List<Customer>> SearchCustomers(string searchTerm)
-        {
-            var customers = _CustomerService.SearchCustomers(searchTerm);
-            return customers;
-        }
-
-        /// <summary>
-        /// Retrieves a specific page of customers based on pagination parameters.
-        /// </summary>
-        /// <param name="pageNumber">The page number.</param>
-        /// <param name="pageSize">The page size.</param>
-        [HttpGet("Page")]
-        public ActionResult<List<Customer>> GetCustomersPage(int pageNumber, int pageSize)
-        {
-            var customers = _CustomerService.GetCustomersPage(pageNumber, pageSize);
-            return customers;
-        }
+        #endregion
     }
 }

--- a/cfms-web-api/cfms-web-api/Controllers/v2/FeedbackController.cs
+++ b/cfms-web-api/cfms-web-api/Controllers/v2/FeedbackController.cs
@@ -1,6 +1,7 @@
 ﻿using cfms_web_api.Interfaces;
 using cfms_web_api.Models;
 using Microsoft.AspNetCore.Mvc;
+using System.Collections.Generic;
 
 namespace cfms_web_api.Controller.v2
 {
@@ -16,13 +17,29 @@ namespace cfms_web_api.Controller.v2
             _FeedbackService = FeedbackService;
         }
 
+        #region GET Methods
+        /// <summary>
+        /// Retrieves all feedbacks.
+        /// </summary>
+        /// <returns>The HTTP status code and a list of all feedbacks.</returns>
+        /// <response code="200">Returns a list of all feedbacks.</response>
         [HttpGet]
+        [ProducesResponseType(200, Type = typeof(List<Feedback>))]
         public ActionResult<List<Feedback>> GetAllFeedbacks()
         {
             return _FeedbackService.GetAllFeedback();
         }
 
+        /// <summary>
+        /// Retrieves feedback by ID.
+        /// </summary>
+        /// <param name="id">The ID of the feedback to retrieve.</param>
+        /// <returns>The HTTP status code and the feedback with the specified ID.</returns>
+        /// <response code="200">Returns the feedback with the specified ID.</response>
+        /// <response code="404">If the feedback is not found.</response>
         [HttpGet("{id}")]
+        [ProducesResponseType(200, Type = typeof(Feedback))]
+        [ProducesResponseType(404)]
         public ActionResult<Feedback> GetFeedbackById(string id)
         {
             var Feedback = _FeedbackService.GetFeedbackById(id);
@@ -33,43 +50,16 @@ namespace cfms_web_api.Controller.v2
             return Feedback;
         }
 
-        [HttpPost]
-        public ActionResult<List<Feedback>> AddFeedback(Feedback feedback)
-        {
-            return _FeedbackService.AddFeedback(feedback);
-        }
-
-        [HttpPost("Bulk")]
-        public ActionResult<List<Feedback>> AddFeedback(List<Feedback> feedbackList)
-        {
-            return _FeedbackService.AddFeedback(feedbackList);
-        }
-
-        [HttpPut("{id}")]
-        public ActionResult<List<Feedback>> UpdateFeedback(string id, Feedback Feedback)
-        {
-            var updatedFeedbacks = _FeedbackService.UpdateFeedback(id, Feedback);
-            if (updatedFeedbacks == null)
-            {
-                return NotFound();
-            }
-            return updatedFeedbacks;
-        }
-
-        [HttpDelete("{id}")]
-        public ActionResult<List<Feedback>> DeleteFeedback(string id)
-        {
-            var deletedFeedbacks = _FeedbackService.DeleteFeedback(id);
-            if (deletedFeedbacks == null)
-            {
-                return NotFound();
-            }
-            return deletedFeedbacks;
-        }
-
-        //New Functions on API v2
-        //Get all feedback records for a particular customer
+        /// <summary>
+        /// Retrieves feedbacks by customer ID.
+        /// </summary>
+        /// <param name="customerId">The ID of the customer to retrieve feedbacks for.</param>
+        /// <returns>The HTTP status code and a list of feedbacks for the specified customer.</returns>
+        /// <response code="200">Returns a list of feedbacks for the specified customer.</response>
+        /// <response code="404">If no feedbacks are found for the specified customer.</response>
         [HttpGet("Customer/{customerId}")]
+        [ProducesResponseType(200, Type = typeof(List<Feedback>))]
+        [ProducesResponseType(404)]
         public ActionResult<List<Feedback>> GetFeedbacksByCustomerId(string customerId)
         {
             List<Feedback> feedbacks = _FeedbackService.GetFeedbacksByCustomerId(customerId);
@@ -79,16 +69,103 @@ namespace cfms_web_api.Controller.v2
             }
             return feedbacks;
         }
+        #endregion
 
-        //Create a new feedback record for a customer
+        #region POST Methods
+        /// <summary>
+        /// Adds a new feedback.
+        /// </summary>
+        /// <param name="feedback">The feedback to add.</param>
+        /// <returns>The HTTP status code and the added feedback.</returns>
+        /// <response code="201">Returns the added feedback.</response>
+        [HttpPost]
+        [ProducesResponseType(201, Type = typeof(List<Feedback>))]
+        public ActionResult<List<Feedback>> AddFeedback(Feedback feedback)
+        {
+            return _FeedbackService.AddFeedback(feedback);
+        }
+
+        /// <summary>
+        /// Adds multiple feedbacks in bulk.
+        /// </summary>
+        /// <param name="feedbackList">The list of feedbacks to add.</param>
+        /// <returns>The HTTP status code and the added feedbacks.</returns>
+        /// <response code="201">Returns the added feedbacks.</response>
+        [HttpPost("Bulk")]
+        [ProducesResponseType(201, Type = typeof(List<Feedback>))]
+        public ActionResult<List<Feedback>> AddFeedback(List<Feedback> feedbackList)
+        {
+            return _FeedbackService.AddFeedback(feedbackList);
+        }
+
+        /// <summary>
+        /// Adds feedback for a specific customer.
+        /// </summary>
+        /// <param name="customerId">The ID of the customer to add feedback for.</param>
+        /// <param name="feedback">The feedback to add.</param>
+        /// <returns>The HTTP status code and the added feedback.</returns>
+        /// <response code="201">Returns the added feedback.</response>
         [HttpPost("Customer/{customerId}")]
+        [ProducesResponseType(201, Type = typeof(List<Feedback>))]
         public ActionResult<List<Feedback>> AddFeedbackForCustomer(string customerId, Feedback feedback)
         {
             feedback.CustomerId = customerId;
             List<Feedback> addedFeedback = _FeedbackService.AddFeedback(customerId, feedback);
             return addedFeedback;
         }
+        #endregion
 
+        #region PUT Methods
+        /// <summary>
+        /// Updates feedback.
+        /// </summary>
+        /// <param name="id">The ID of the feedback to update.</param>
+        /// <param name="Feedback">The updated feedback data.</param>
+        /// <returns>The HTTP status code and the updated feedback.</returns>
+        /// <response code="200">Returns the updated feedback.</response>
+        /// <response code="404">If the feedback is not found.</response>
+        /// <response code="400">If the updated feedback data is not in the correct format.</response>
+        /// <response code="422">If the updated feedback data is invalid.</response>
+        /// <response code="500">If an exception was thrown.</response>
+        [HttpPut("{id}")]
+        [ProducesResponseType(200, Type = typeof(List<Feedback>))]
+        [ProducesResponseType(404)]
+        [ProducesResponseType(400)]
+        [ProducesResponseType(422)]
+        [ProducesResponseType(500)]
+        public ActionResult<List<Feedback>> UpdateFeedback(string id, Feedback Feedback)
+        {
+            var updatedFeedbacks = _FeedbackService.UpdateFeedback(id, Feedback);
+            if (updatedFeedbacks == null)
+            {
+                return NotFound();
+            }
+            return updatedFeedbacks;
+        }
+        #endregion
+
+        #region DELETE Methods
+        /// <summary>
+        /// Deletes feedback.
+        /// </summary>
+        /// <param name="id">The ID of the feedback to delete.</param>
+        /// <returns>The HTTP status code.</returns>
+        /// <response code="200">If the deletion was successful.</response>
+        /// <response code="404">If the feedback is not found.</response>
+        /// <response code="500">If an exception was thrown.</response>
+        [HttpDelete("{id}")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(404)]
+        [ProducesResponseType(500)]
+        public ActionResult<List<Feedback>> DeleteFeedback(string id)
+        {
+            var deletedFeedbacks = _FeedbackService.DeleteFeedback(id);
+            if (deletedFeedbacks == null)
+            {
+                return NotFound();
+            }
+            return deletedFeedbacks;
+        }
+        #endregion
     }
 }
-

--- a/cfms-web-api/cfms-web-api/Controllers/v2/FeedbackController.cs
+++ b/cfms-web-api/cfms-web-api/Controllers/v2/FeedbackController.cs
@@ -1,7 +1,6 @@
 ﻿using cfms_web_api.Interfaces;
 using cfms_web_api.Models;
 using Microsoft.AspNetCore.Mvc;
-using System.Collections.Generic;
 
 namespace cfms_web_api.Controller.v2
 {
@@ -166,6 +165,30 @@ namespace cfms_web_api.Controller.v2
             }
             return deletedFeedbacks;
         }
+
+        /// <summary>
+        /// Deletes all feedback entries.
+        /// </summary>
+        /// <returns>The HTTP status code.</returns>
+        /// <response code="200">If all feedback entries were deleted successfully.</response>
+        /// <response code="500">If an exception was thrown.</response>
+        [HttpDelete("All")]
+        [ProducesResponseType(200)]
+        [ProducesResponseType(500)]
+        public IActionResult DeleteAllFeedback()
+        {
+            try
+            {
+                _FeedbackService.DeleteAllFeedback();
+                return Ok();
+            }
+            catch (Exception ex)
+            {
+                //TODO: Logging
+                return StatusCode(500);
+            }
+        }
+
         #endregion
     }
 }

--- a/cfms-web-api/cfms-web-api/Interfaces/ICustomerRepository.cs
+++ b/cfms-web-api/cfms-web-api/Interfaces/ICustomerRepository.cs
@@ -6,13 +6,16 @@ namespace cfms_web_api.Interfaces
 	{
         List<Customer> GetAllCustomers();
         Customer GetCustomerById(string id);
-        List<Customer> AddCustomer(Customer customer);
-        List<Customer> AddCustomers(List<Customer> customers);
-        List<Customer> UpdateCustomer(string id, Customer customer);
-        List<Customer> DeleteCustomer(string id);
-
         List<Customer> SearchCustomers(string searchTerm);
         List<Customer> GetCustomersPage(int pageNumber, int pageSize);
+
+        List<Customer> AddCustomer(Customer customer);
+        List<Customer> AddCustomers(List<Customer> customers);
+
+        List<Customer> UpdateCustomer(string id, Customer customer);
+
+        List<Customer> DeleteCustomer(string id);
+        void DeleteAllCustomers();
     }
 }
 

--- a/cfms-web-api/cfms-web-api/Interfaces/ICustomerService.cs
+++ b/cfms-web-api/cfms-web-api/Interfaces/ICustomerService.cs
@@ -7,13 +7,15 @@ namespace cfms_web_api.Interfaces
 	{
         List<Customer> GetAllCustomers();
         Customer GetCustomerById(string id);
+        List<Customer> SearchCustomers(string searchTerm);
+        List<Customer> GetCustomersPage(int pageNumber, int pageSize);
+
         List<Customer> AddCustomer(Customer customer);
         List<Customer> AddCustomers(List<Customer> customers);
         List<Customer> UpdateCustomer(string id, Customer customer);
-        List<Customer> DeleteCustomer(string id);
 
-        List<Customer> SearchCustomers(string searchTerm);
-        List<Customer> GetCustomersPage(int pageNumber, int pageSize);
+        List<Customer> DeleteCustomer(string id);
+        void DeleteAllCustomers();
     }
 }
 

--- a/cfms-web-api/cfms-web-api/Interfaces/IFeedbackRepository.cs
+++ b/cfms-web-api/cfms-web-api/Interfaces/IFeedbackRepository.cs
@@ -6,14 +6,16 @@ namespace cfms_web_api.Interfaces
 	{
         List<Feedback> GetAllFeedback();
         Feedback GetFeedbackById(string id);
+        List<Feedback> GetFeedbacksByCustomerId(string customerId);
 
         List<Feedback> AddFeedback(Feedback feedback);
         List<Feedback> AddFeedback(List<Feedback> feedback);
         List<Feedback> AddFeedback(string customerId, Feedback feedback);
 
         List<Feedback> UpdateFeedback(string id, Feedback feedback);
+
         List<Feedback> DeleteFeedback(string id);
-        List<Feedback> GetFeedbacksByCustomerId(string customerId);
+        void DeleteAllFeedback();
     }
 }
 

--- a/cfms-web-api/cfms-web-api/Program.cs
+++ b/cfms-web-api/cfms-web-api/Program.cs
@@ -6,12 +6,15 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.Extensions.Options;
 using Swashbuckle.AspNetCore.SwaggerGen;
+using Swashbuckle.AspNetCore.SwaggerUI;
 
 var builder = WebApplication.CreateBuilder(args);
-//Swagger/OpenAPI
+
 builder.Services.AddSwaggerGen(options =>
 {
     options.DocumentFilter<SwaggerDocumentFilter>();
+    var docFile = $"{typeof(Program).Assembly.GetName().Name}.xml";
+    options.IncludeXmlComments(Path.Combine(AppContext.BaseDirectory, docFile));
 });
 
 // Add services to the container.
@@ -47,6 +50,17 @@ if (app.Environment.IsDevelopment())
     app.UseSwagger();
     app.UseSwaggerUI(options =>
     {
+        options.DefaultModelExpandDepth(2);
+        options.DefaultModelRendering(ModelRendering.Model);
+        options.DefaultModelsExpandDepth(-1);
+        options.DisplayOperationId();
+        options.DisplayRequestDuration();
+        options.DocExpansion(DocExpansion.None);
+        options.EnableDeepLinking();
+        options.EnableFilter();
+        options.ShowExtensions();
+
+        // Specify Swagger endpoints for each API version
         foreach (var desc in versionDescProvider.ApiVersionDescriptions)
         {
             options.SwaggerEndpoint($"/swagger/{desc.GroupName}/swagger.json", $"Customer Feedback API v{desc.GroupName.ToUpper()}");

--- a/cfms-web-api/cfms-web-api/Repositories/CustomerRepository.cs
+++ b/cfms-web-api/cfms-web-api/Repositories/CustomerRepository.cs
@@ -85,6 +85,12 @@ namespace cfms_web_api.Data
             return _context.Customers.ToList();
         }
 
+        public void DeleteAllCustomers()
+        {
+            _context.Customers.RemoveRange(_context.Customers);
+            _context.SaveChanges();
+        }
+
         public List<Customer> SearchCustomers(string searchTerm)
         {
             return _context.Customers

--- a/cfms-web-api/cfms-web-api/Repositories/FeedbackRepository.cs
+++ b/cfms-web-api/cfms-web-api/Repositories/FeedbackRepository.cs
@@ -94,6 +94,12 @@ namespace cfms_web_api.Controller
         {
             return _context.Feedbacks.Where(f => f.CustomerId.Equals(customerId)).ToList();
         }
+
+        public void DeleteAllFeedback()
+        {
+            _context.Feedbacks.RemoveRange(_context.Feedbacks);
+            _context.SaveChanges();
+        }
     }
 
 }

--- a/cfms-web-api/cfms-web-api/Services/CustomerService.cs
+++ b/cfms-web-api/cfms-web-api/Services/CustomerService.cs
@@ -27,6 +27,11 @@ namespace cfms_web_api.Controller
             return _CustomerRepository.DeleteCustomer(id);
         }
 
+        public void DeleteAllCustomers()
+        {
+            _CustomerRepository.DeleteAllCustomers();
+        }
+
         public List<Customer> GetAllCustomers()
         {
             return _CustomerRepository.GetAllCustomers();

--- a/cfms-web-api/cfms-web-api/Services/FeedbackService.cs
+++ b/cfms-web-api/cfms-web-api/Services/FeedbackService.cs
@@ -50,6 +50,11 @@ namespace cfms_web_api.Controller
             return _FeedbackRepository.DeleteFeedback(id);
         }
 
+        public void DeleteAllFeedback()
+        {
+            _FeedbackRepository.DeleteAllFeedback();
+        }
+
         public List<Feedback> GetFeedbacksByCustomerId(string customerId)
         {
             return _FeedbackRepository.GetFeedbacksByCustomerId(customerId);


### PR DESCRIPTION
This pull request includes two main changes:

1. Grouping of API endpoints in SwaggerUI:
   - Implemented functionality to group API endpoints in SwaggerUI based on their functionality and source code structure.
   - Grouped controllers and action methods using the `[ApiExplorerSettings]` attribute to categorise them effectively in the SwaggerUI interface.

2. Bulk delete function:
   - Introduced a new functionality for bulk deletion of feedback and customer entries.
   - Added methods `DeleteAllFeedback()` to the `IFeedbackRepository` interface and implemented them using Entity Framework to delete all record entries from the database in one go.
   - Created corresponding HTTP DELETE endpoints `DeleteAllFeedback` in the `FeedbackController` to expose the bulk delete functionality to clients.
   - Included appropriate Swagger annotations for the new endpoint to document its usage and response codes in the SwaggerUI interface.