### PR TITLE
Versioned web api

### DIFF
--- a/cfms-web-api/cfms-web-api/Controllers/v1/CustomerController.cs
+++ b/cfms-web-api/cfms-web-api/Controllers/v1/CustomerController.cs
@@ -6,8 +6,9 @@ namespace cfms_web_api.Controller.v1
 {
     [Route("[controller]")]
     [Route("v{version:apiVersion}/[controller]")]
-    [ApiVersion("1.0")]
+    [ApiVersion("1.0", Deprecated = true)]
     [ApiController]
+    [Obsolete]
     public class CustomersController : ControllerBase
     {
         private readonly ICustomerService _CustomerService;

--- a/cfms-web-api/cfms-web-api/Controllers/v1/FeedbackController.cs
+++ b/cfms-web-api/cfms-web-api/Controllers/v1/FeedbackController.cs
@@ -6,8 +6,9 @@ namespace cfms_web_api.Controller.v1
 {
     [Route("[controller]")]
     [Route("v{version:apiVersion}/[controller]")]
-    [ApiVersion("1.0")]
+    [ApiVersion("1.0", Deprecated = true)]
     [ApiController]
+    [Obsolete]
     public class FeedbackController : ControllerBase
     {
         private readonly IFeedbackService _FeedbackService;

--- a/cfms-web-api/cfms-web-api/Interfaces/IFeedbackService.cs
+++ b/cfms-web-api/cfms-web-api/Interfaces/IFeedbackService.cs
@@ -6,14 +6,16 @@ namespace cfms_web_api.Interfaces
 	{
         List<Feedback> GetAllFeedback();
         Feedback GetFeedbackById(string id);
+        List<Feedback> GetFeedbacksByCustomerId(string customerId);
 
         List<Feedback> AddFeedback(Feedback feedback);
         List<Feedback> AddFeedback(List<Feedback> feedback);
         List<Feedback> AddFeedback(string customerId, Feedback feedback);
 
         List<Feedback> UpdateFeedback(string id, Feedback feedback);
+
         List<Feedback> DeleteFeedback(string id);
-        List<Feedback> GetFeedbacksByCustomerId(string customerId);
+        void DeleteAllFeedback();
     }
 }
 

--- a/cfms-web-api/cfms-web-api/Program.cs
+++ b/cfms-web-api/cfms-web-api/Program.cs
@@ -63,7 +63,8 @@ if (app.Environment.IsDevelopment())
         // Specify Swagger endpoints for each API version
         foreach (var desc in versionDescProvider.ApiVersionDescriptions)
         {
-            options.SwaggerEndpoint($"/swagger/{desc.GroupName}/swagger.json", $"Customer Feedback API v{desc.GroupName.ToUpper()}");
+            options.SwaggerEndpoint($"/swagger/{desc.GroupName}/swagger.json",
+                $"Customer Feedback API v{desc.GroupName.ToUpper()}{(desc.IsDeprecated ? " (deprecated)" : "")}");
         }
     });
 }


### PR DESCRIPTION
Forgot to add  functionality for bulk deletion of Customer entries.
   - Added methods DeleteAllCustomers()` to `ICustomerRepository` and implemented them using Entity Framework to delete all record entries from the database in one go.
   - Created corresponding HTTP DELETE endpoints `DeleteAllCustomers` in the `CustomerController` to expose the bulk delete functionality to clients.